### PR TITLE
Fix dozer repair assignments not working

### DIFF
--- a/iron-dominion/js/ui.js
+++ b/iron-dominion/js/ui.js
@@ -218,11 +218,16 @@ function updateCard(){
   const myUnits=sel.filter(s=>s.kind==='u');
   const dz=myUnits.find(u=>u.type==='dozer');
   if(dz){
-    // Show active assignment with a cancel shortcut so the player doesn't need to find the site
+    // Show active assignment with a cancel shortcut
     if(dz.site&&!dz.site.dead){
       const s=dz.site;
       cardEl.appendChild(mkInfo('<b>🔧 Building:</b> '+s.t.ic+' '+dispName('b',s.type,0)+' — '+Math.floor(s.prog*100)+'%'));
-      cardEl.appendChild(mkBtn('🗑','Cancel build',0,'warn',()=>cancelSite(s)));
+      cardEl.appendChild(mkBtn('🗑','Cancel',0,'warn',()=>cancelSite(s)));
+    } else if(dz.fix&&!dz.fix.dead){
+      const b=dz.fix;
+      const pct=Math.round(b.hp/b.maxhp*100);
+      cardEl.appendChild(mkInfo('<b>🔩 Repairing:</b> '+b.t.ic+' '+dispName('b',b.type,0)+' — '+pct+'% HP'));
+      cardEl.appendChild(mkBtn('✕','Stop repair',0,'warn',()=>{dz.fix=null;dz.path=null;SFX.click();updateCard()}));
     }
     cardEl.appendChild(mkInfo('<b>🚜 '+dispName('u','dozer',0)+'</b>Pick a structure:'));
     const REQ={tech:'barracks',silo:'factory',airfield:'factory',samsite:'power',market:'tech',command:'tech'};
@@ -332,7 +337,7 @@ function commandTarget(hit){
   }
   if(hit.kind==='b'&&hit.team===0&&hit.built&&hit.hp<hit.maxhp){
     let n=0;
-    for(const u of sel)if(u.kind==='u'&&u.type==='dozer'&&!u.dead){u.fix=hit;u.site=null;u.order=null;u.attackTarget=null;u.path=null;n++}
+    for(const u of sel)if(u.kind==='u'&&u.type==='dozer'&&!u.dead){u.fix=hit;u.site=null;u.order=null;u.attackTarget=null;u.path=null;u.repath=0;n++}
     if(n){SFX.click();toast('🔧 Dozer repairing '+dispName('b',hit.type,0));return true}
   }
   // Garrison: infantry into a civil structure (neutral or friendly)
@@ -417,6 +422,8 @@ function tap(px,py,isCmd){
     }
     if(hit.team===0){
       if(hit.kind==='b'&&!hit.built&&sel.some(x=>x.kind==='u'&&x.type==='dozer'&&!x.dead)){resumeSite(hit);return}
+      // Let commandTarget handle repair/garrison before falling back to selection
+      if(sel.some(s=>s.kind==='u')&&commandTarget(hit))return;
       selectEnt(hit);return;
     }
     if(hit.team<0){  // neutral building

--- a/iron-dominion/sw.js
+++ b/iron-dominion/sw.js
@@ -1,4 +1,4 @@
-const CACHE='iron-dominion-v17';
+const CACHE='iron-dominion-v18';
 const ASSETS=['.','index.html','css/style.css','manifest.json','icon-192.png','icon-512.png',
   'js/audio.js','js/config.js','js/state.js','js/helpers.js','js/world.js',
   'js/units.js','js/buildings.js','js/projectiles.js','js/ai.js',


### PR DESCRIPTION
Root cause: contextual tap (left-click/touch) for friendly buildings went straight to selectEnt() without ever calling commandTarget(). Right-click worked because it routes through commandTarget() explicitly. Mobile users could never assign repairs via tap.

Fixes:
- Tap on friendly building while units selected now tries commandTarget() before falling back to selectEnt() — repair and garrison assignments now work via tap/touch, not just right-click
- u.repath=0 reset when fix is assigned so dozer starts pathfinding immediately rather than waiting up to 1s
- Dozer card shows active repair assignment ("🔩 Repairing: X — 72% HP") with a Stop repair button — same UX as construction assignments
- Stop repair button clears fix+path so dozer can be reassigned

https://claude.ai/code/session_01BtQf7CryA4s4EZ89xrf7kM